### PR TITLE
Add sni support

### DIFF
--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -6,7 +6,7 @@ import six
 import socket
 from base64 import b64encode
 from six.moves.urllib.parse import urlparse, urlunparse
-from ssl import SSLError
+from ssl import create_default_context, SSLError
 from timeit import default_timer
 
 if six.PY2:
@@ -87,6 +87,13 @@ class FastHttpSession(object):
         
         # Check for basic authentication
         parsed_url = urlparse(self.base_url)
+        if parsed_url.scheme == "https" and parsed_url.hostname:
+            self.client = LocustUserAgent(
+                max_retries=1,
+                cookiejar=self.cookiejar,
+                ssl_context_factory=create_default_context,
+                ssl_options={"server_hostname": parsed_url.hostname},
+            )
         if parsed_url.username and parsed_url.password:
             netloc = parsed_url.hostname
             if parsed_url.port:

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -6,7 +6,7 @@ import six
 import socket
 from base64 import b64encode
 from six.moves.urllib.parse import urlparse, urlunparse
-from ssl import create_default_context, SSLError
+from gevent.ssl import create_default_context, SSLError
 from timeit import default_timer
 
 if six.PY2:

--- a/locust/contrib/fasthttp.py
+++ b/locust/contrib/fasthttp.py
@@ -179,7 +179,9 @@ class FastHttpSession(object):
         
         if catch_response:
             response.locust_request_meta = request_meta
-            return ResponseContextManager(response)
+            context = ResponseContextManager(response)
+            context._cached_content = response.content
+            return context
         else:
             try:
                 response.raise_for_status()


### PR DESCRIPTION
**WORK IN PROGRESS - DO NOT MERGE**

A quick hack to add basic SNI support to the fasthttp client

Use an SSL context for the geventhttp connection pool, which supports passing server_hostname to the SSL connection wrapper.
This is passed to the server for selecting the correct certificate, when SNI is in use.